### PR TITLE
Improve ywasm performance by 2x (ymap_set case)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "buddy-alloc"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0d2da64a6a895d5a7e0724882825d50f83c13396b1b9f1878e19a024bab395"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,12 +103,6 @@ name = "cc"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -177,7 +177,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen",
 ]
 
@@ -187,7 +187,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -305,7 +305,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi",
@@ -331,7 +331,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crunchy",
 ]
 
@@ -414,6 +414,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,12 +434,6 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "miniz_oxide"
@@ -702,6 +706,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "str_indices"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,12 +795,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "talc"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04be12ec299aadd63a0bf781d893e4b6139d33cdca6dcd6f6be31f849cedcac8"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "rustix",
  "windows-sys",
@@ -866,7 +894,7 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -891,7 +919,7 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -962,34 +990,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,12 +997,6 @@ checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -1110,13 +1104,15 @@ name = "ywasm"
 version = "0.19.2"
 dependencies = [
  "base64_light",
+ "buddy-alloc",
  "console_error_panic_hook",
  "gloo-utils",
  "js-sys",
  "serde",
  "serde_json",
+ "spin",
+ "talc",
  "wasm-bindgen",
  "wasm-bindgen-test",
- "wee_alloc",
  "yrs",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,15 +752,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "str_indices"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,7 +1094,6 @@ dependencies = [
  "js-sys",
  "serde",
  "serde_json",
- "spin",
  "talc",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,12 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
-name = "buddy-alloc"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0d2da64a6a895d5a7e0724882825d50f83c13396b1b9f1878e19a024bab395"
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,7 +1098,6 @@ name = "ywasm"
 version = "0.19.2"
 dependencies = [
  "base64_light",
- "buddy-alloc",
  "console_error_panic_hook",
  "gloo-utils",
  "js-sys",

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -5,15 +5,20 @@ use crate::types::TypePtr;
 use crate::utils::client_hasher::ClientHasher;
 use crate::*;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap};
 use std::hash::BuildHasherDefault;
-use std::ops::{Index, IndexMut};
+use std::ops::{Index, IndexMut, Range, RangeInclusive};
 use std::vec::Vec;
 
 /// A resizable list of blocks inserted by a single client.
 #[derive(PartialEq, Default)]
 pub(crate) struct ClientBlockList {
     list: Vec<BlockCell>,
+}
+
+struct SquashBlockRange {
+    range: Range<usize>,
+    gc_block: bool
 }
 
 impl ClientBlockList {
@@ -123,6 +128,112 @@ impl ClientBlockList {
     pub fn iter(&self) -> ClientBlockListIter<'_> {
         ClientBlockListIter(self.list.iter())
     }
+
+    /// Attempts to squash multiple blocks within the given range of indices.
+    /// For each block in the `indices_range`, it will check if the block can be squashed with its left neighbor.
+    /// If consecutive blocks are squashable, they are tracked in a range and processed in bulk to compact
+    /// the list efficiently. The function supports both GC and Block cells.
+    ///
+    /// - For GC blocks: If blocks are consecutive, the range is extended and squashing is deferred until
+    ///   all squashable blocks are identified.
+    ///
+    /// - For Block cells: The function attempts to squash the contents of the right block into the left block.
+    ///   If successful, it tracks the blocks to be removed and rewires references in the parent node if necessary.
+    ///   Block cells currently don't support range compaction due to the complexity of squashing Blocks.
+    ///
+    /// The function processes all blocks in reverse order (from the end of the range to the start),
+    /// compacts the list by removing squashed blocks, and updates references for any parent-child relationships
+    /// affected by the squashing.
+    ///
+    /// # Arguments
+    /// * `indices_range` - A range of indices, where each index represents a block in the list to be examined
+    ///   for squashing. The range must be non-empty (`start` must be <= `end`).
+    ///
+    /// # Panics
+    /// * Panics if `indices_range.start()` is greater than `indices_range.end()`.
+    ///
+    pub(crate) fn squash_left_range_compaction(&mut self, indices_range: RangeInclusive<usize>) {
+        assert!(indices_range.start() <= indices_range.end());
+        let mut squash_intervals: Vec<SquashBlockRange> = Vec::new();
+
+        for right_index in indices_range.rev() {
+            let (l, r) = self.list.split_at_mut(right_index);
+            let left = &mut l.last_mut().unwrap();
+            let right = &mut r[0];
+
+            match (left, right) {
+                (BlockCell::GC(left), BlockCell::GC(right)) => {
+                    let mut extended = false;
+                    match squash_intervals.last_mut() {
+                        Some(last_range) if last_range.gc_block => {
+                            // Extend if consecutive
+                            if last_range.range.start - 1 == right_index {
+                                last_range.range.start = right_index;
+                                extended = true;
+                            }
+                        }
+                        _ => {}
+                    }
+
+                    if !extended {
+                        // Add new range if no consecutive block found
+                        squash_intervals.push(SquashBlockRange {
+                            range: Range {
+                                start: right_index,
+                                end: right_index,
+                            },
+                            gc_block: true,
+                        });
+                    }
+                }
+                (BlockCell::Block(left), BlockCell::Block(right)) => {
+                    let mut left = ItemPtr::from(left);
+                    let right = ItemPtr::from(right);
+                    if left.try_squash(right) {
+                        // Merge right into left Blocks one by one.
+                        squash_intervals.push(SquashBlockRange { range: Range {start: right_index, end: right_index }, gc_block: false });
+                    }
+                }
+                _ => { /* cannot squash incompatible types */ }
+            }
+        }
+
+        for squash_range in &squash_intervals {
+            let start_idx = squash_range.range.start;
+            let end_idx = squash_range.range.end;
+            assert!(start_idx <= end_idx);
+
+            let (left_slice, right_slice) = self.list.split_at_mut(end_idx);
+
+            // The start_idx - 1 element is the one want to squash into.
+            let left = &mut left_slice[start_idx - 1];
+            let right = &right_slice[0];
+
+            match (left, right) {
+                (BlockCell::GC(left), BlockCell::GC(right)) => {
+                    left.end = right.end;
+                }
+                (BlockCell::Block(left), BlockCell::Block(right)) => {
+                    let mut left = ItemPtr::from(left);
+                    let right = ItemPtr::from(right);
+                    if let Some(key) = right.parent_sub.as_deref() {
+                        if let TypePtr::Branch(mut parent) = right.parent {
+                            if let Some(e) = parent.map.get_mut(key) {
+                                if right == *e {
+                                    *e = ItemPtr::from(left);
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => { /* cannot squash incompatible types */ }
+            }
+
+            // Finally, remove the BlockCells in bulk.
+            self.list.drain(start_idx..=end_idx);
+        }
+    }
+
 
     /// Attempts to squash block at a given `index` with a corresponding block on its left side.
     /// If this succeeds, block under a given `index` will be removed, and its contents will be

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -31,7 +31,7 @@ base64_light = "0.1"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
 js-sys = "0.3"
-talc="*"
+talc="4.4.1"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -18,7 +18,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 yrs = { path = "../yrs", version = "0.19.2", features = ["weak"] }
-wasm-bindgen = { version = "0.2" }
+wasm-bindgen = { version = "0.2.92" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 gloo-utils = { version = "0.2", features = ["serde"] }

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -31,7 +31,6 @@ base64_light = "0.1"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
 js-sys = "0.3"
-spin = "0.9.8"
 talc="*"
 
 [dev-dependencies]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -29,14 +29,10 @@ base64_light = "0.1"
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
-
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however.
-#
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.5", optional = true }
 js-sys = "0.3"
+spin = "0.9.8"
+talc="*"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/ywasm/js/reflection.js
+++ b/ywasm/js/reflection.js
@@ -1,5 +1,7 @@
 // See js.rs #[wasm_bindgen(module = "/js/reflection.js")]
 
+const JS_PTR = "__wbg_ptr";
+
 export function getWasmPtr(target) {
     const ptr = target[JS_PTR];
 

--- a/ywasm/js/reflection.js
+++ b/ywasm/js/reflection.js
@@ -34,3 +34,31 @@ export function getTypeJs(target) {
         return 255;
     }
 }
+
+export function handleAsValue(target, functor) {
+    let resultEnum = -1;
+    let resultNumber = 0.0;
+
+    if (target === undefined) {
+        resultEnum = 0;
+    } else if (target === null) {
+        resultEnum = 1;
+    } else if (typeof target === 'number') {
+        resultEnum = 2;
+        resultNumber = target;
+    } else if (typeof target === 'boolean') {
+        resultEnum = 3;
+        resultNumber = target ? 1.0 : 0.0;
+    } else if (typeof target === 'bigint') {
+        resultEnum = 4;
+        resultNumber = Number(target);
+    } else if (typeof target === 'string') {
+        resultEnum = 5;
+    } else if (Array.isArray(target)) {
+        resultEnum = 6;
+    } else if (typeof(target) === 'object') {
+        resultEnum = 7;
+    }
+
+    functor(resultEnum, resultNumber);
+}

--- a/ywasm/js/reflection.js
+++ b/ywasm/js/reflection.js
@@ -1,21 +1,5 @@
 // See js.rs #[wasm_bindgen(module = "/js/reflection.js")]
 
-const NON_TRANSACTION = "provided argument was not a ywasm transaction";
-const INVALID_TRANSACTION_CTX = "cannot modify transaction in this context";
-const REF_DISPOSED = "shared collection has been destroyed";
-const ANOTHER_TX = "another transaction is in progress";
-const ANOTHER_RW_TX = "another read-write transaction is in progress";
-const OUT_OF_BOUNDS = "index outside of the bounds of an array";
-const KEY_NOT_FOUND = "key was not found in a map";
-const INVALID_PRELIM_OP = "preliminary type doesn't support this operation";
-const INVALID_FMT = "given object cannot be used as formatting attributes";
-const INVALID_XML_ATTRS = "given object cannot be used as XML attributes";
-const NOT_XML_TYPE = "provided object is not a valid XML shared type";
-const NOT_PRELIM = "this operation only works on preliminary types";
-const NOT_WASM_OBJ = "provided reference is not a WebAssembly object";
-const INVALID_DELTA = "invalid delta format";
-const JS_PTR = "__wbg_ptr";
-
 export function getWasmPtr(target) {
     const ptr = target[JS_PTR];
 

--- a/ywasm/js/reflection.js
+++ b/ywasm/js/reflection.js
@@ -1,5 +1,31 @@
 // See js.rs #[wasm_bindgen(module = "/js/reflection.js")]
 
+const NON_TRANSACTION = "provided argument was not a ywasm transaction";
+const INVALID_TRANSACTION_CTX = "cannot modify transaction in this context";
+const REF_DISPOSED = "shared collection has been destroyed";
+const ANOTHER_TX = "another transaction is in progress";
+const ANOTHER_RW_TX = "another read-write transaction is in progress";
+const OUT_OF_BOUNDS = "index outside of the bounds of an array";
+const KEY_NOT_FOUND = "key was not found in a map";
+const INVALID_PRELIM_OP = "preliminary type doesn't support this operation";
+const INVALID_FMT = "given object cannot be used as formatting attributes";
+const INVALID_XML_ATTRS = "given object cannot be used as XML attributes";
+const NOT_XML_TYPE = "provided object is not a valid XML shared type";
+const NOT_PRELIM = "this operation only works on preliminary types";
+const NOT_WASM_OBJ = "provided reference is not a WebAssembly object";
+const INVALID_DELTA = "invalid delta format";
+const JS_PTR = "__wbg_ptr";
+
+export function getWasmPtr(target) {
+    const ptr = target[JS_PTR];
+
+    if (typeof ptr !== 'number') {
+        throw new Error(NOT_WASM_OBJ);
+    }
+
+    return ptr;
+}
+
 export function getTypeJs(target) {
     const tag = target.type;
     if (typeof tag === 'number') {

--- a/ywasm/js/reflection.js
+++ b/ywasm/js/reflection.js
@@ -1,0 +1,10 @@
+// See js.rs #[wasm_bindgen(module = "/js/reflection.js")]
+
+export function getTypeJs(target) {
+    const tag = target.type;
+    if (typeof tag === 'number') {
+        return tag & 0xff;
+    } else {
+        return 255;
+    }
+}

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -157,14 +157,23 @@ impl Js {
                 let mut failed = false;
                 for value in array.iter() {
                     let js = Js::from(value);
-                    // FIXME!!: this was js.as_value()? before! the else statement doesn't work!
-                    if let ValueRef::Any(any) = js.as_value().unwrap() {
-                        vec_result.push(any);
-                    } else {
-                        result = Err(js.0.clone());
-                        failed = true;
-                        break;
+
+                    match js.as_value() {
+                        Ok(ValueRef::Any(any)) => {
+                            vec_result.push(any);
+                        }
+                        Ok(_) => {
+                            result = Err(js.0.clone());
+                            failed = true;
+                            break;
+                        }
+                        Err(_) => {
+                            result = Err(js.0.clone());
+                            failed = true;
+                            break;
+                        }
                     }
+
                 }
 
                 if !failed {
@@ -194,15 +203,24 @@ impl Js {
 
                         let value = tuple.get(1);
                         let js = Js(value.clone());
-                        // FIXME!!: this was js.as_value()? before! the else statement doesn't work!
-                        if let ValueRef::Any(any) = js.as_value().unwrap() {
-                            map.insert(key, any);
-                        } else {
-                            result = Err(value);
-                            failed = true;
-                            break;
+
+                        match js.as_value() {
+                            Ok(ValueRef::Any(any)) => {
+                                map.insert(key, any);
+                            }
+                            Ok(_) => {
+                                result = Err(value);
+                                failed = true;
+                                break;
+                            }
+                            Err(_) => {
+                                result = Err(value);
+                                failed = true;
+                                break;
+                            }
                         }
                     }
+
                     if !failed {
                         result = Ok(ValueRef::Any(Any::Map(Arc::new(map))))
                     }

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -129,9 +129,7 @@ impl Js {
     }
 
     pub fn as_value(&self) -> Result<ValueRef> {
-        if let Some(str) = self.0.as_string() {
-            Ok(ValueRef::Any(Any::from(str)))
-        } else if self.0.is_null() {
+        if self.0.is_null() {
             Ok(ValueRef::Any(Any::Null))
         } else if self.0.is_undefined() {
             Ok(ValueRef::Any(Any::Undefined))
@@ -139,6 +137,8 @@ impl Js {
             Ok(ValueRef::Any(Any::Number(f)))
         } else if let Some(b) = self.0.as_bool() {
             Ok(ValueRef::Any(Any::Bool(b)))
+        } else if let Some(js_str) = self.0.dyn_ref::<JsString>() {
+            Ok(ValueRef::Any(Any::from(js_str.as_string().unwrap())))
         } else if self.0.is_bigint() {
             let i = js_sys::BigInt::from(self.0.clone()).as_f64().unwrap();
             Ok(ValueRef::Any(Any::BigInt(i as i64)))

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -144,7 +144,7 @@ impl Js {
             } else if in_type == 2 {
                 result = Ok(ValueRef::Any(Any::Number(value)))
             } else if in_type == 3 {
-                result = Ok(ValueRef::Any(Any::Bool(if value > 0.0 { true } else { false })))
+                result = Ok(ValueRef::Any(Any::Bool(value > 0.0)))
             } else if in_type == 4 {
                 let i = value;
                 result = Ok(ValueRef::Any(Any::BigInt(i as i64)))

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -613,7 +613,7 @@ pub(crate) mod convert {
     where
         T: RefMutFromWasmAbi<Abi = u32>,
     {
-        let ptr_u32 = get_wasm_ptr(js).ok().ok_or(JsValue::from_str(crate::js::errors::NOT_WASM_OBJ))? as u32;
+        let ptr_u32 = get_wasm_ptr(js).ok().unwrap() as u32;
         let target = unsafe { T::ref_mut_from_abi(ptr_u32) };
         Ok(target)
     }

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -8,14 +8,14 @@ use crate::xml_elem::YXmlElement;
 use crate::xml_frag::YXmlFragment;
 use crate::xml_text::YXmlText;
 use crate::Result;
-use js_sys::Uint8Array;
+use js_sys::{JsString, Uint8Array};
 use std::collections::{Bound, HashMap};
 use std::convert::TryInto;
 use std::ops::{Deref, RangeBounds};
 use std::sync::Arc;
 use wasm_bindgen::__rt::RefMut;
 use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, RefMutFromWasmAbi};
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen::prelude::wasm_bindgen;
 use yrs::block::{EmbedPrelim, ItemContent, Prelim, Unused};
 use yrs::branch::{Branch, BranchPtr};
@@ -35,7 +35,7 @@ extern "C" {
     fn get_type_js(target: &JsValue) -> u8;
 
     #[wasm_bindgen(js_name = "getWasmPtr", catch)]
-    fn get_wasm_ptr(target: &JsValue) -> Result<f64>;
+    pub fn get_wasm_ptr(target: &JsValue) -> Result<f64>;
 }
 
 #[repr(transparent)]

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use wasm_bindgen::__rt::RefMut;
 use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi};
 use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::wasm_bindgen;
 use yrs::block::{EmbedPrelim, ItemContent, Prelim, Unused};
 use yrs::branch::{Branch, BranchPtr};
 use yrs::types::xml::XmlPrelim;
@@ -27,6 +28,12 @@ use yrs::{
     Any, ArrayRef, BranchID, Doc, Map, MapRef, Origin, Out, Text, TextRef, TransactionMut, WeakRef,
     Xml, XmlElementRef, XmlFragment, XmlFragmentRef, XmlOut, XmlTextRef,
 };
+
+#[wasm_bindgen(module = "/js/reflection.js")]
+extern "C" {
+    #[wasm_bindgen(js_name = getTypeJs)]
+    fn get_type_js(target: &JsValue) -> u8;
+}
 
 #[repr(transparent)]
 pub struct Js(JsValue);
@@ -50,9 +57,9 @@ impl Js {
     }
 
     pub fn get_type(js: &JsValue) -> crate::Result<u8> {
-        let tag = js_sys::Reflect::get(js, &JsValue::from_str("type"))?;
-        if let Some(tag) = tag.as_f64() {
-            Ok(tag as u8)
+        let tag = get_type_js(js);
+        if tag != 255 {
+            Ok(tag)
         } else {
             Err(js.clone())
         }

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -43,6 +43,11 @@ pub use crate::undo::YUndoManager as UndoManager;
 pub use crate::weak::YWeakLink as WeakLink;
 pub use crate::weak::YWeakLinkEvent as WeakLinkEvent;
 
+// SAFETY: The runtime environment must be single-threaded WASM.
+#[cfg(all(target_family = "wasm"))]
+#[global_allocator]
+static ALLOCATOR: talc::TalckWasm = unsafe { talc::TalckWasm::new_global() };
+
 /// When called will call console log errors whenever internal panic is called from within
 /// WebAssembly module.
 #[wasm_bindgen(js_name = setPanicHook)]

--- a/ywasm/src/transaction.rs
+++ b/ywasm/src/transaction.rs
@@ -86,11 +86,7 @@ impl YTransaction {
         if abi == 0 {
             Err(JsValue::from_str(crate::js::errors::NON_TRANSACTION))
         } else {
-            let ptr = js_sys::Reflect::get(&value, &JsValue::from_str(crate::js::JS_PTR))?;
-            let ptr_u32 = ptr
-                .as_f64()
-                .ok_or(JsValue::from_str(crate::js::errors::NOT_WASM_OBJ))?
-                as u32;
+            let ptr_u32 = crate::js::get_wasm_ptr(value).ok().ok_or(JsValue::from_str(crate::js::errors::NOT_WASM_OBJ))? as u32;
             let target = unsafe { YTransaction::ref_mut_from_abi(ptr_u32) };
             Ok(target)
         }


### PR DESCRIPTION
This change set contains various optimizations to ywasm.
- Optimize hot path calls that end up crossing the JavaScript boundary. (Checkout: https://hacks.mozilla.org/2018/10/calls-between-javascript-and-webassembly-are-finally-fast-%F0%9F%8E%89/)
- Use talc instead of dlmalloc for global heap allocations. Negligible imporvement, but faster is faster.